### PR TITLE
Reset styles after lists

### DIFF
--- a/wordinserter/renderers/com.py
+++ b/wordinserter/renderers/com.py
@@ -322,6 +322,7 @@ class COMRenderer(BaseRenderer):
 
         if first_list:
             self.selection.Range.ListFormat.RemoveNumbers(NumberType=self.constants.wdNumberParagraph)
+            self.selection.Style = self.constants.wdStyleNormal
         else:
             self.selection.Range.ListFormat.ListOutdent()
 


### PR DESCRIPTION
I found an issue where a hyperlink after a list was formatted as a list. The problem comes from the hyperlink handler doing `self.selection.Style = style` because the previous style had a class applied and the end section of the list handler calls `RemoveNumbers` but never unsets this style. 
I tried saving the style beforehand and restoring it afterwards, but it does not seem to have any effect. I'm not sure this is a good solution, but it does fix the issue I'm seeing, submitting this to see what you think
