### PR TITLE
Add support for rotated text in table cells

### DIFF
--- a/wordinserter/operations.py
+++ b/wordinserter/operations.py
@@ -250,6 +250,7 @@ class Format(Operation):
         "margin",
         "vertical_align",
         "text_align",
+        "writing_mode",
         "width",
         "height",
         "border"

--- a/wordinserter/renderers/com.py
+++ b/wordinserter/renderers/com.py
@@ -595,6 +595,13 @@ class COMRenderer(BaseRenderer):
                 if op.text_align in alignment:
                     parent_operation.render.cell_object.Range.ParagraphFormat.Alignment = alignment[op.text_align]
 
+        if op.writing_mode:
+            orientations = {"vertical-lr": 1, "sideways-lr": 2}
+            if isinstance(parent_operation, TableCell):
+                orientation = orientations.get(op.writing_mode)
+                if orientation is not None:
+                    parent_operation.render.cell_object.Range.Orientation = orientation
+
         if op.border:
             if isinstance(parent_operation, Image):
                 img = parent_operation.render.image


### PR DESCRIPTION
The CSS attributes are not widely supported but I think they'll do for specifying this case.
