### PR TITLE
Fix fields over-running and remaining bold after pressing F9

### DIFF
--- a/wordinserter/renderers/com.py
+++ b/wordinserter/renderers/com.py
@@ -293,8 +293,9 @@ class COMRenderer(BaseRenderer):
                 Text=text,
                 PreserveFormatting=True
             )
-            # When inserting fields, the cursor stays at the beginning, select it so it collapses to the end of it
+            # When inserting fields, the cursor stays at the beginning, select it and move the cursor to escape from it
             field.Result.Select()
+            self.selection.MoveRight()
         else:
             self.document.Hyperlinks.Add(Anchor=rng, Address=op.location)
         self.selection.Collapse(Direction=self.constants.wdCollapseEnd)

--- a/wordinserter/renderers/com.py
+++ b/wordinserter/renderers/com.py
@@ -279,7 +279,7 @@ class COMRenderer(BaseRenderer):
             self.document.Hyperlinks.Add(Anchor=rng, TextToDisplay="", SubAddress=op.location.replace('#', '', 1))
         elif op.location.startswith('!') or op.location.startswith('@'):
             if op.location.startswith('!'):
-                text = "REF {} \h".format(op.location.replace('!', '', 1))
+                text = "REF {} \h \* charformat".format(op.location.replace('!', '', 1))
             else:
                 text = op.location.replace('@', '', 1)
                 code = text.split(' ')[0]
@@ -291,7 +291,7 @@ class COMRenderer(BaseRenderer):
                 Range=rng,
                 Type=self.constants.wdFieldEmpty,
                 Text=text,
-                PreserveFormatting=True
+                PreserveFormatting=False
             )
             # When inserting fields, the cursor stays at the beginning, select it and move the cursor to escape from it
             field.Result.Select()


### PR DESCRIPTION
`selection.Collapse(Direction=self.constants.wdCollapseEnd)` was not enough to escape the `field` formatting, so anything typed afterwards would be considered part of it, and therefore lost when updating their content. Using `MoveRight()` is a little hacky but it's the only thing I could find that works. 

Using `charformat` instead of `PreserveFormatting=True` allows preserving some formatting while getting rid of the bold formatting when the field ref does not exist at the moment of the field creation.