### PR TITLE
Prevent out of memory error on very long hyperlinks

### DIFF
--- a/wordinserter/renderers/com.py
+++ b/wordinserter/renderers/com.py
@@ -297,7 +297,7 @@ class COMRenderer(BaseRenderer):
             field.Result.Select()
             self.selection.MoveRight()
         else:
-            self.document.Hyperlinks.Add(Anchor=rng, Address=op.location)
+            self.document.Hyperlinks.Add(Anchor=rng, Address=op.location[:2048])  # Prevent out of memory error
         self.selection.Collapse(Direction=self.constants.wdCollapseEnd)
         self.selection.Style = style
 


### PR DESCRIPTION
Our server died because of a very long hyperlink. Experimentally 2070 seems to be the limit on my local instance, setting it a bit lower just to be safe, cheers.