### PR TITLE
Add support for inserting page breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+Add support for inserting page breaks
+
 ## 1.1.2
 Fix hyperlinks/styles/code sections inside textboxes
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if os.path.exists('README.rst'):
 
 setup(
     name='wordinserter',
-    version='1.1.2',
+    version='1.1.3',
     packages=find_packages(),
     url='https://github.com/orf/wordinserter',
     license='MIT',

--- a/wordinserter/operations.py
+++ b/wordinserter/operations.py
@@ -282,7 +282,8 @@ class Format(Operation):
         "border",
         "display",
         "padding",
-        "line_height"
+        "line_height",
+        "page_break_after"
     }
 
     FORMAT_ALIASES = {

--- a/wordinserter/renderers/com.py
+++ b/wordinserter/renderers/com.py
@@ -187,7 +187,9 @@ class COMRenderer(BaseRenderer):
 
     @renders(LineBreak)
     def linebreak(self, op: LineBreak):
-        if isinstance(op.parent, Paragraph) or isinstance(op.parent, Group) and op.parent.is_root_group:
+        if op.format.page_break_after == "always":
+            self.selection.InsertBreak(self.constants.wdPageBreak)
+        elif isinstance(op.parent, Paragraph) or isinstance(op.parent, Group) and op.parent.is_root_group:
             self.selection.TypeParagraph()
 
     @renders(Paragraph)


### PR DESCRIPTION
Uses the `page_break_after` CSS attribute on `<br>` tags